### PR TITLE
Add Github Actions Workflow for Pull Requests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+on:
+  pull_request:
+    branches:
+    - main
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - id: go
+      name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - id: test
+      name: Go Tests
+      run: |
+        go test -coverprofile=coverage.out ./...
+    - id: compile
+      name: Compile
+      run: |
+        GOOS=darwin GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go
+        GOOS=linux GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go
+        GOOS=windows GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow triggered on pull requests to run go tests and to cross compile the application for all supported platforms:
- darwin / amd64
- linux / amd64
- windows / amd64