### PR TITLE
Default Values in CopyJob Specification

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -13,7 +13,9 @@ specify a `target` section.
 ## `target.address`
 
 Use `target.address` to specify the scheme, host, and port address of the target
-Vault server.
+Vault server. If this key is not provided the Vault client will be configured
+using the **VAULT_ADDR** environment variable if it's set, otherwise it will
+default to `https://127.0.0.1:8200` as the Vault address.
 
 ## `target.login`
 
@@ -62,7 +64,7 @@ perform a login operation and obtain a valid Vault token.
       "kubernetes": {
         "mount-point": "kubernetes",
         "role": "my-role",
-        "jwt-path": "/var/run/secrets/kubernetes.io/serviceaccount"
+        "jwt-path": "/var/run/secrets/kubernetes.io/serviceaccount/token"
       }
     }
   },
@@ -73,7 +75,8 @@ perform a login operation and obtain a valid Vault token.
 ## `target.login.kubernetes.mount-point`
 
 Use `target.login.kubernetes.mount-point` to specify the path where the
-Kubernetes authentication method that will be used is mounted.
+Kubernetes authentication method that will be used is mounted. If this key is
+not provided, the *mount-point* is assumed to be `kubernetes`.
 
 ## `target.login.kubernetes.role`
 
@@ -83,7 +86,9 @@ Kubernetes authentication method to use for the login operation.
 ## `target.login.kubernetes.jwt-path`
 
 Use `target.login.kubernetes.jwt-path` to specify the path on the local file
-system from which the Kubernetes Service Account token is to be retrieved.
+system from which the Kubernetes Service Account token is to be retrieved.  If
+this key is not provided, the *jwt-path* is assumed to be
+`/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 ## `sources`
 
@@ -116,7 +121,8 @@ source Vault.
 ## `copies[*].mount-point`
 
 Use the `copies[*].mount-point` key to specify the path where the KV Secrets
-Engine of the target secret is mounted.
+Engine of the target secret is mounted. If this key is not provided, the
+*mount-point* is assumed to be `kv`.
 
 ## `copies[*].path`
 
@@ -171,15 +177,20 @@ the appropriate source Vault in the `sources` section above.
 ## `copies[*].values.<value_name>.mount-point`
 
 Use the `copies[*].values.<value_name>.mount-point` key to specify the path
-where the KV Secrets Engine of the tarsourceget secret is mounted.
+where the KV Secrets Engine of the tarsourceget secret is mounted. If this key
+is not provided, the *mount-point* is assumed to be `kv`.
 
 ## `copies[*].values.<value_name>.path`
 
 Use the `copies[*].values.<value_name>.path` key to specify the path of the
-source secret within its KV Secrets Engine.
+source secret within its KV Secrets Engine. If this key is not provided, the
+source *path* is assumed to be the same as the target *path* specified in the
+`copies[*].path` key.
 
 ## `copies[*].values.<value_name>.key`
 
 Use the `copies[*].values.<value_name>.key` key to specify the key of the
 key-value mapping within the source secret to copy into the `<value_name>`
-mapping in the target secret.
+mapping in the target secret. If this key is not provided, the source *key* is
+assumed to be the same as the target key specified in the 
+`copies[*].values.<value_name>` key.

--- a/copy.go
+++ b/copy.go
@@ -30,16 +30,36 @@ func NewCopy(spec *spec.Copy, sources map[string]Vault) (*Copy, error) {
 			return nil, fmt.Errorf("secret value %q is referencing a non-existing source Vault", k)
 		}
 
+		mountPoint := "kv"
+		if v.MountPoint != "" {
+			mountPoint = v.MountPoint
+		}
+
+		path := spec.Path
+		if v.Path != "" {
+			path = v.Path
+		}
+
+		key := k
+		if v.Key != "" {
+			key = v.Key
+		}
+
 		copyValues[k] = &CopyValue{
 			Source:     sourceVault,
-			MountPoint: v.MountPoint,
-			Path:       v.Path,
-			Key:        v.Key,
+			MountPoint: mountPoint,
+			Path:       path,
+			Key:        key,
 		}
 	}
 
+	mountPoint := "kv"
+	if spec.MountPoint != "" {
+		mountPoint = spec.MountPoint
+	}
+
 	return &Copy{
-		MountPoint: spec.MountPoint,
+		MountPoint: mountPoint,
 		Path:       spec.Path,
 		Values:     copyValues,
 	}, nil

--- a/copy_test.go
+++ b/copy_test.go
@@ -85,6 +85,95 @@ func TestNewCopySetsVaultSource(t *testing.T) {
 	assert.Equal(t, fakeVault.Name(), copy.Values["t1"].Source.Name())
 }
 
+func TestNewCopyHandlesDefaultValues(t *testing.T) {
+	for _, testcase := range []struct {
+		spec                     *spec.Copy
+		expectedMountPoint       string
+		expectedValuesMountPoint string
+		expectedValuesPath       string
+		expectedValuesKey        string
+	}{
+		// mount-point omitted
+		{
+			spec: &spec.Copy{
+				Path: "path1",
+				Values: map[string]*spec.CopyValue{
+					"k": {
+						Source:     "s1",
+						MountPoint: "vkv",
+						Path:       "vpath1",
+						Key:        "vk1",
+					},
+				},
+			},
+			expectedMountPoint:       "kv",
+			expectedValuesMountPoint: "vkv",
+			expectedValuesPath:       "vpath1",
+			expectedValuesKey:        "vk1",
+		},
+		// values mount-point omitted
+		{
+			spec: &spec.Copy{
+				MountPoint: "kv1",
+				Path:       "path1",
+				Values: map[string]*spec.CopyValue{
+					"k": {
+						Source: "s1",
+						Path:   "vpath1",
+						Key:    "vk1",
+					},
+				},
+			},
+			expectedMountPoint:       "kv1",
+			expectedValuesMountPoint: "kv",
+			expectedValuesPath:       "vpath1",
+			expectedValuesKey:        "vk1",
+		},
+		// values path omitted
+		{
+			spec: &spec.Copy{
+				MountPoint: "kv1",
+				Path:       "path1",
+				Values: map[string]*spec.CopyValue{
+					"k": {
+						Source:     "s1",
+						MountPoint: "vkv1",
+						Key:        "vk1",
+					},
+				},
+			},
+			expectedMountPoint:       "kv1",
+			expectedValuesMountPoint: "vkv1",
+			expectedValuesPath:       "path1",
+			expectedValuesKey:        "vk1",
+		},
+		// values key omitted
+		{
+			spec: &spec.Copy{
+				MountPoint: "kv1",
+				Path:       "path1",
+				Values: map[string]*spec.CopyValue{
+					"k": {
+						Source:     "s1",
+						MountPoint: "vkv1",
+						Path:       "vpath1",
+					},
+				},
+			},
+			expectedMountPoint:       "kv1",
+			expectedValuesMountPoint: "vkv1",
+			expectedValuesPath:       "vpath1",
+			expectedValuesKey:        "k",
+		},
+	} {
+		copy, _ := NewCopy(testcase.spec, map[string]Vault{"s1": &FakeVault{}})
+		assert.Equal(t, testcase.expectedMountPoint, copy.MountPoint)
+		assert.Equal(t, testcase.expectedValuesMountPoint, copy.Values["k"].MountPoint)
+		assert.Equal(t, testcase.expectedValuesPath, copy.Values["k"].Path)
+		assert.Equal(t, testcase.expectedValuesKey, copy.Values["k"].Key)
+	}
+}
+
 func TestTargetUpdateTime(t *testing.T) {
 	for _, testcase := range []struct {
 		copy         *Copy

--- a/vault_test.go
+++ b/vault_test.go
@@ -64,3 +64,23 @@ func TestVaultName(t *testing.T) {
 // 	handleIntegrationTest(t)
 
 // }
+
+func TestNewVaultHandlesDefault(t *testing.T) {
+	for _, testcase := range []struct {
+		spec            *spec.Vault
+		expectedAddress string
+	}{
+		// Address omitted
+		{
+			spec: &spec.Vault{
+				Login: &spec.VaultLogin{
+					Token: "root",
+				},
+			},
+			expectedAddress: "https://127.0.0.1:8200",
+		},
+	} {
+		vault, _ := NewVault(testcase.spec, "test")
+		assert.Equal(t, testcase.expectedAddress, vault.(*realVault).client.Address())
+	}
+}


### PR DESCRIPTION
This PR changes the behaviour of the application to apply specific default values when certain keys are missing from the CopyJob specification.

The *SPECIFICATION.md* file has been updated to indicate which keys are now optional as well as what default value is used in their absence.

Here's a summary of the now optional keys:
* `target.address`
* `sources.<source_name>.address`
* `copies[*].mount-point`
* `copies[*].values.<value_name>.mount-point`
* `copies[*].values.<value_name>.path`
* `copies[*].values.<value_name>.key`