### PR TITLE
Dockerize Application and Add golint to Workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.github/
+.vscode/
+testing/
+*_test.go
+coverage.out
+Dockerfile
+hvc
+README.md
+SPECIFICATION.md

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,9 +18,9 @@ jobs:
       name: Go Tests
       run: |
         go test -coverprofile=coverage.out ./...
-    - id: compile
-      name: Compile
-      run: |
-        GOOS=darwin GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go
-        GOOS=linux GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go
-        GOOS=windows GOARCH=amd64 go build -o hvc-${GOOS}_${GOARCH} ./cmd/hvc/main.go
+    - id: lint
+      name: Go Lint
+      uses: Jerome1337/golint-action@v1.0.2
+      with:
+        golint-path: './...'
+        

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.17.9-alpine3.15 AS build
+
+WORKDIR /go/src/hvm
+
+COPY . .
+
+RUN go install /go/src/hvm/cmd/hvc
+
+FROM alpine:3.15
+
+WORKDIR /usr/bin
+
+COPY --from=build /go/bin/hvc .
+
+ENTRYPOINT [ "hvc" ]
+
+CMD [ "help" ]

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -15,6 +15,7 @@ func init() {
 	rootCmd.AddCommand(copy.CopyCmd)
 }
 
+// Execute executes the rootCmd's Run function.
 func Execute() {
 	rootCmd.Execute()
 }

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// CopyCmd is the cobra.Command that handles the copy option of this
+// application.
 var CopyCmd = &cobra.Command{
 	Use:   "copy",
 	Short: "Copies secrets according to copy job specification",

--- a/copy.go
+++ b/copy.go
@@ -22,6 +22,8 @@ type Copy struct {
 	Values map[string]*CopyValue
 }
 
+// NewCopy creates a Copy structure using the provided spec.Copy structure and
+// map of source names to Vault interfaces.
 func NewCopy(spec *spec.Copy, sources map[string]Vault) (*Copy, error) {
 	copyValues := make(map[string]*CopyValue)
 	for k, v := range spec.Values {
@@ -90,6 +92,11 @@ func (p *Copy) TargetUpdateTime(target Vault) (time.Time, error) {
 	return targetTime, nil
 }
 
+// DetermineNeedToCopy retrieves the metadata for every source secret referenced
+// by a Copy structure and compares the updated time from each with the provided
+// target time. If any source updated time is more recent than the target time,
+// the function will return true, otherwise it will return false. If an error is
+// encountered, false and the error will be returned.
 func (p *Copy) DetermineNeedToCopy(targetTime time.Time) (bool, error) {
 	// Update time cache
 	sourceUpdateTimes := make(map[string]time.Time)
@@ -117,6 +124,8 @@ func (p *Copy) DetermineNeedToCopy(targetTime time.Time) (bool, error) {
 	return needsUpdate, nil
 }
 
+// UpdateTargetSecret updates the target secret referenced in the receiver using
+// the provided target Vault interface.
 func (p *Copy) UpdateTargetSecret(target Vault) error {
 	targetData := make(map[string]interface{})
 
@@ -147,10 +156,14 @@ func (p *Copy) UpdateTargetSecret(target Vault) error {
 	return nil
 }
 
+// Name returns a canonical name for the receiver.
 func (p *Copy) Name() string {
 	return fmt.Sprintf("%s/%s", p.MountPoint, p.Path)
 }
 
+// Execute executes the copy operation of the receiver using the provided target
+// Vault interface. The function uses the provided index and channel to report
+// any errors encountered.
 func (p *Copy) Execute(target Vault, index int, ch chan error) {
 	// Get the metadata of the secret in the target Vault server
 	targetTime, err := p.TargetUpdateTime(target)

--- a/copyjob.go
+++ b/copyjob.go
@@ -24,11 +24,12 @@ type CopyJob struct {
 func NewCopyJob(spec *spec.CopyJob) (*CopyJob, error) {
 	copyJob := &CopyJob{}
 
-	if targetVault, err := NewVault(spec.Target, "_target"); err != nil {
+	targetVault, err := NewVault(spec.Target, "_target")
+	if err != nil {
 		return nil, fmt.Errorf("failed to initialize target Vault: %w", err)
-	} else {
-		copyJob.Target = targetVault
 	}
+
+	copyJob.Target = targetVault
 
 	sourceVaults := make(map[string]Vault)
 	for sourceVaultKey, sourceVaultSpec := range spec.Sources {
@@ -53,7 +54,7 @@ func NewCopyJob(spec *spec.CopyJob) (*CopyJob, error) {
 	return copyJob, nil
 }
 
-// ExecuteCopy copies the secret values referenced in the provided Copy
+// Execute copies the secret values referenced in the provided Copy
 // structure using the receiver's configured target and source Vault
 // connections.
 func (p *CopyJob) Execute() []error {

--- a/spec/copyjob.go
+++ b/spec/copyjob.go
@@ -26,6 +26,8 @@ type CopyJob struct {
 	Copies []*Copy `json:"copies"`
 }
 
+// LoadSpec creates a CopyJob structure from the data read from the provided
+// Reader interface.
 func LoadSpec(in io.Reader) (*CopyJob, error) {
 	specBytes, err := ioutil.ReadAll(in)
 	if err != nil {

--- a/spec/copyvalue.go
+++ b/spec/copyvalue.go
@@ -1,6 +1,6 @@
 package spec
 
-// CopyValueSpec defines the source for a value within the target secret.
+// CopyValue defines the source for a value within the target secret.
 type CopyValue struct {
 	// Source is the name of the defined Vault structure in the Sources field of
 	// the CopyJob structure.


### PR DESCRIPTION
This PR changes the GitHub Actions workflow triggered by pull requests to remove the cross-platform builds (`go build` commands) and instead adds a step to run the golint command.

All reported golint errors have been addressed in this PR as well.

This PR also introduces a Dockerfile that can be used to build a Docker image containing this application.