### PR TITLE
Ignore .DS_Store Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode
 coverage.out
 hvc


### PR DESCRIPTION
This PR adds `.DS_Store` to the _.gitignore_ file so that they don't get included in commits.