### PR TITLE
Update README.md with Instructions on how to Run hvc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,18 @@ on:
   push:
     branches:
       - main
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      packages: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: go
@@ -34,17 +38,26 @@ jobs:
             .
     - id: docker-login
       name: Docker Hub Login
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       env:
         PASSWORD: ${{ secrets.DOCKERHUBPASSWORD }}
-      run: |
-        echo "$PASSWORD" | docker login \
-            -u marcboudreau \
-            --password-stdin \
-            docker.io
+    - id: docker-meta
+      name: Extract metadata
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     - id: docker-push
       name: Docker Push
-      run: |
-        docker push -a marcboudreau/hvc
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
     - id: tag
       name: Tag Repository
       run: |

--- a/README.md
+++ b/README.md
@@ -3,18 +3,32 @@
 
 <img align="left" alt="Vault Copying" src="./copy.png" width="67" height="80" style="margin:5px"/>
 
-This project builds the **hvc** application that facilitates copying secrets
-from one or more Vault server(s) to a single target Vault server.
+The **hvc** application copies secrets from one or more source Vault servers to
+a single target Vault server.
 
-It features the ability to copy secrets to a Vault server using source secrets
-from one or more source Vault servers.
-
+Each copied secret can be sourced from a single secret (exact copy) or it can be
+sourced using multiple keys from different secrets.  The source secrets can also
+span different source Vault servers.
 
 ## Usage
 
-This section explains how to use this application.  The application uses a
-**Copy Job Specification** file to model which secrets are copied to a target
+This section explains how to use the **hvc** application.  The application uses
+a **Copy Job Specification** file to model which secrets are copied to a target
 Vault.
+
+### Running
+
+The **hhvc** application can be run in a Docker container as follows:
+
+```
+$ docker run -t -v $PWD/spec.json:/hvc/spec.json marcboudreau/hvc /hvc/spec.json
+```
+
+In this example, the *spec.json* file situated in the current working directory
+is mounted into the container and used as the Copy Job Specification.
+
+The **hvc** application can be run as a Kubernetes Job as demonstrated in the
+[kubernetes_example.md](./kubernetes_example.md) file.
 
 ### Copy Job Specification
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Vault.
 
 ### Running
 
-The **hhvc** application can be run in a Docker container as follows:
+The **hvc** application can be run in a Docker container as follows:
 
 ```
-$ docker run -t -v $PWD/spec.json:/hvc/spec.json marcboudreau/hvc /hvc/spec.json
+$ docker run -t -v $PWD/spec.json:/hvc/spec.json ghcr.io/marcboudreau/hvc /hvc/spec.json
 ```
 
 In this example, the *spec.json* file situated in the current working directory

--- a/kubernetes_example.md
+++ b/kubernetes_example.md
@@ -1,0 +1,101 @@
+Kubernetes Job Usage Example
+============================
+
+This example shows how **hvc** can be used as a Kubernetes Job. The example
+shows both the **kubernetes** and **token** authentication strategies being 
+employed in the **Copy Job Specification**.
+
+The example assumes that the target Vault server has a Kubernetes Authentication
+Method enabled at the standard path `auth/kubernetes` and it has a Role named
+`hvc` defined that will allow the **hvc** Kubernetes Service Account to be used
+to authenticate.
+
+### Security Note
+
+This example is tailored for simplicity over security, which is why a Kubernetes
+Secret is created without any consideration to protect its value.  In a
+production environment, the Kubernetes Secret should be created out-of-band and
+proper measures should be taken to not disclose the secret's value.
+
+```
+$ echo 'apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hvc
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: source-vault-token
+stringData:
+  vault-token: s.0123456789abcdefghijklmn
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spec
+data:
+  spec.json: |
+    {
+      "target": {
+        "address": "http://target.vault:8200"
+        "login": {
+          "kubernetes": {
+            "role": "hvc"
+          }
+        }
+      },
+      "sources": {
+        "s1": {
+          "address": "http://source.vault:8200"
+          "login": {
+            "token": "${SOURCE_VAULT_TOKEN}"
+          }
+        }
+      },
+      "copies": [
+        {
+          "path": "p1/secret"
+          "secret": {
+            "source": "s1",
+            "path": "p1/secret"
+          }
+        }
+      ]
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hvc
+spec:
+  completions: 1
+  template:
+    metadata:
+    spec:
+      volumes:
+      - name: spec
+        configMap:
+          name: spec
+          items:
+          - key: spec.json
+            path: ./spec.json
+      containers:
+      - name: hvc
+        image: marcboudreau/hvc:latest
+        args:
+        - copy
+        - /mnt/spec.json
+        env:
+        - name: SOURCE_VAULT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: source-vault-token
+              key: vault-token
+        volumeMounts:
+        - name: spec
+          mountPath: /mnt
+      restartPolicy: Never
+      serviceAccountName: hvc
+' | kubectl apply -f -
+```


### PR DESCRIPTION
This PR adds a sub-section under **Usage** in the _README.md_ file to show how to run **hvc** as a Docker container and  provides a link to a new file to show how to run **hvc** as a Kubernetes Job.