### PR TITLE
fix:broken release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
     - uses: actions/checkout@v3
@@ -45,19 +45,13 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
       env:
         PASSWORD: ${{ secrets.DOCKERHUBPASSWORD }}
-    - id: docker-meta
-      name: Extract metadata
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     - id: docker-push
       name: Docker Push
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
         context: .
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}
     - id: tag
       name: Tag Repository
       run: |


### PR DESCRIPTION
Re-instating write permission on contents in workflow to allow tagging to work.